### PR TITLE
pin janus to 0.4.0

### DIFF
--- a/imjoy/VERSION
+++ b/imjoy/VERSION
@@ -1,4 +1,4 @@
 {
-    "version": "0.9.10",
+    "version": "0.9.11",
     "api_version": "0.1.2"
 }

--- a/imjoy/workers/python3_client.py
+++ b/imjoy/workers/python3_client.py
@@ -123,7 +123,7 @@ class AsyncClient(BaseClient):
         """Set up client instance."""
         super().__init__(id)
         self.loop = asyncio.get_event_loop()
-        self.janus_queue = janus.Queue()
+        self.janus_queue = janus.Queue(loop=self.loop)
         self.queue = self.janus_queue.sync_q
         self.task_worker = task_worker
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,5 @@ pytest==4.4.1
 pytest-cov==2.7.1
 pytest-timeout==1.3.3
 pytest-asyncio==0.10.0
-janus==0.5.0
+janus==0.4.0
 numpy==1.15.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ WORKER_REQUIREMENTS = [
     "python-engineio==3.9.1",
     "python-socketio[client]==4.4.0",
     "numpy",
-    'janus==0.5.0;python_version>"3.3"',
+    'janus==0.4.0;python_version>"3.3"',
     'pathlib;python_version<"3.4"',
 ]
 

--- a/tests/mock_plugin.py
+++ b/tests/mock_plugin.py
@@ -49,7 +49,7 @@ class TestPlugin:
         self._plugin_message_handler = []
         self.api = None
         self.imjoy_api = ImJoyAPI()
-        self.janus_queue = janus.Queue()
+        self.janus_queue = janus.Queue(loop=self.loop)
         self.queue = self.janus_queue.sync_q
 
         @sio.on("message_from_plugin_" + secret)


### PR DESCRIPTION
According to a discussion in #92 , using janus 0.5.0 would require major changes on how we organize our code, so for now, we will just pin janus to 0.4.0.