### PR TITLE
Add utility function show_elfinder

### DIFF
--- a/imjoy/VERSION
+++ b/imjoy/VERSION
@@ -1,4 +1,4 @@
 {
-    "version": "0.10.9",
+    "version": "0.10.10",
     "api_version": "0.2.0"
 }

--- a/imjoy/__init__.py
+++ b/imjoy/__init__.py
@@ -1,6 +1,10 @@
 """Package the ImJoy plugin engine."""
 import json
 import os
+import threading
+import time
+
+from imjoy_rpc import api
 
 # read version information from file
 IMJOY_PACKAGE_DIR = os.path.dirname(__file__)
@@ -9,4 +13,58 @@ with open(os.path.join(IMJOY_PACKAGE_DIR, "VERSION"), "r") as f:
     __version__ = VERSION_INFO["version"]
     API_VERSION = VERSION_INFO["api_version"]
 
-from imjoy_rpc import api
+_server_thread = None
+
+
+def _show_elfinder_colab(root_dir="/content", port=8765, height=600, width="100%"):
+    from google.colab import output
+    from imjoy_elfinder.app import main
+
+    global _server_thread
+    if _server_thread is None:
+
+        def start_elfinder():
+            global _server_thread
+            try:
+                main(["--root-dir={}".format(root_dir), "--port={}".format(port)])
+            except OSError:
+                print("ImJoy-elFinder server already started.")
+            _server_thread = thread
+
+        # start imjoy-elfinder server
+        thread = threading.Thread(target=start_elfinder)
+        thread.start()
+
+    time.sleep(1)
+    output.serve_kernel_port_as_iframe(port, height=str(height), width=str(width))
+
+
+def _show_elfinder_jupyter(url="/elfinder", height=600, width="100%"):
+    from IPython import display
+
+    code = """(async (url, width, height, element) => {
+        element.appendChild(document.createTextNode(''));
+        const iframe = document.createElement('iframe');
+        iframe.src = url;
+        iframe.height = height;
+        iframe.width = width;
+        iframe.style.border = 0;
+        element.appendChild(iframe);
+        })""" + "({url}, {width}, {height}, element[0])".format(
+        url=json.dumps(url), width=json.dumps(width), height=json.dumps(height)
+    )
+    display.display(display.Javascript(code))
+
+
+def show_elfinder(**kwargs):
+    try:
+        from google.colab import output
+
+        is_colab = True
+    except:
+        is_colab = False
+
+    if is_colab:
+        _show_elfinder_colab(**kwargs)
+    else:
+        _show_elfinder_jupyter(**kwargs)

--- a/imjoy/__init__.py
+++ b/imjoy/__init__.py
@@ -1,8 +1,6 @@
 """Package the ImJoy plugin engine."""
 import json
 import os
-import threading
-import time
 
 from imjoy_rpc import api
 
@@ -12,59 +10,3 @@ with open(os.path.join(IMJOY_PACKAGE_DIR, "VERSION"), "r") as f:
     VERSION_INFO = json.load(f)
     __version__ = VERSION_INFO["version"]
     API_VERSION = VERSION_INFO["api_version"]
-
-_server_thread = None
-
-
-def _show_elfinder_colab(root_dir="/content", port=8765, height=600, width="100%"):
-    from google.colab import output
-    from imjoy_elfinder.app import main
-
-    global _server_thread
-    if _server_thread is None:
-
-        def start_elfinder():
-            global _server_thread
-            try:
-                main(["--root-dir={}".format(root_dir), "--port={}".format(port)])
-            except OSError:
-                print("ImJoy-elFinder server already started.")
-            _server_thread = thread
-
-        # start imjoy-elfinder server
-        thread = threading.Thread(target=start_elfinder)
-        thread.start()
-
-    time.sleep(1)
-    output.serve_kernel_port_as_iframe(port, height=str(height), width=str(width))
-
-
-def _show_elfinder_jupyter(url="/elfinder", height=600, width="100%"):
-    from IPython import display
-
-    code = """(async (url, width, height, element) => {
-        element.appendChild(document.createTextNode(''));
-        const iframe = document.createElement('iframe');
-        iframe.src = url;
-        iframe.height = height;
-        iframe.width = width;
-        iframe.style.border = 0;
-        element.appendChild(iframe);
-        })""" + "({url}, {width}, {height}, element[0])".format(
-        url=json.dumps(url), width=json.dumps(width), height=json.dumps(height)
-    )
-    display.display(display.Javascript(code))
-
-
-def show_elfinder(**kwargs):
-    try:
-        from google.colab import output
-
-        is_colab = True
-    except:
-        is_colab = False
-
-    if is_colab:
-        _show_elfinder_colab(**kwargs)
-    else:
-        _show_elfinder_jupyter(**kwargs)

--- a/imjoy/utils.py
+++ b/imjoy/utils.py
@@ -1,10 +1,13 @@
 """Provide utilities that should not be aware of ImJoy engine."""
 import copy
-from importlib import import_module
+import json
 import os
 import string
 import sys
+import threading
+import time
 import uuid
+from importlib import import_module
 
 if sys.platform == "win32":
     from ctypes import windll
@@ -18,6 +21,63 @@ if sys.platform == "win32":
                 drives.append(os.path.abspath(letter + ":/"))
             bitmask >>= 1
         return drives
+
+
+_server_thread = None
+
+
+def _show_elfinder_colab(root_dir="/content", port=8765, height=600, width="100%"):
+    from google.colab import output
+    from imjoy_elfinder.app import main
+
+    global _server_thread
+    if _server_thread is None:
+
+        def start_elfinder():
+            global _server_thread
+            try:
+                main(["--root-dir={}".format(root_dir), "--port={}".format(port)])
+            except OSError:
+                print("ImJoy-elFinder server already started.")
+            _server_thread = thread
+
+        # start imjoy-elfinder server
+        thread = threading.Thread(target=start_elfinder)
+        thread.start()
+
+    time.sleep(1)
+    output.serve_kernel_port_as_iframe(port, height=str(height), width=str(width))
+
+
+def _show_elfinder_jupyter(url="/elfinder", height=600, width="100%"):
+    from IPython import display
+
+    code = """(async (url, width, height, element) => {
+        element.appendChild(document.createTextNode(''));
+        const iframe = document.createElement('iframe');
+        iframe.src = url;
+        iframe.height = height;
+        iframe.width = width;
+        iframe.style.border = 0;
+        element.appendChild(iframe);
+        })""" + "({url}, {width}, {height}, element[0])".format(
+        url=json.dumps(url), width=json.dumps(width), height=json.dumps(height)
+    )
+    display.display(display.Javascript(code))
+
+
+def show_elfinder(**kwargs):
+    try:
+        from google.colab import output
+
+        is_colab = True
+    except:
+        is_colab = False
+
+    if is_colab:
+        _show_elfinder_colab(**kwargs)
+    else:
+        _show_elfinder_jupyter(**kwargs)
 
 
 def read_or_generate_token(token_path=None):

--- a/imjoy/utils.py
+++ b/imjoy/utils.py
@@ -71,7 +71,7 @@ def show_elfinder(**kwargs):
         from google.colab import output
 
         is_colab = True
-    except:
+    except ImportError:
         is_colab = False
 
     if is_colab:

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,14 @@ try:
 
     REQUIREMENTS = [
         "numpy",
-        "imjoy-rpc>=0.2.23",
+        "imjoy-rpc>=0.2.30",
         'pathlib;python_version<"3.4"',
+        "imjoy-elfinder",
     ]
 except:
     REQUIREMENTS = [
         "numpy",
-        "imjoy-rpc>=0.2.23",
+        "imjoy-rpc>=0.2.30",
         'pathlib;python_version<"3.4"',
         "jupyter>=1.0.0",
         "imjoy-elfinder[jupyter]",


### PR DESCRIPTION
This PR add a utility function `imjoy.utils.show_elfinder` which support both jupyter notebooks and google colab:
```python
from imjoy.utils import show_elfinder
show_elfinder()
```
![Screenshot 2020-09-25 at 01 01 03](https://user-images.githubusercontent.com/478667/94208653-9da66c80-feca-11ea-8a01-2daab11a79d7.png)
