### PR TITLE
Bump and pin requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-imjoy-rpc>=0.2.56
-python-socketio[asyncio_client]
-pyyaml
-aiohttp
-aiohttp_cors
+imjoy-rpc==0.2.72
+python-socketio[asyncio_client]==5.2.1
+pyyaml==5.4.1
+aiohttp==3.7.4.post0
+aiohttp_cors==0.7.0
+numpy==1.19.5  # needs to stay compatible with latest tensorflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-imjoy-rpc==0.2.72
-python-socketio[asyncio_client]==5.2.1
+imjoy-rpc==0.2.56
+python-socketio[asyncio_client]==5.0.4  # pin for now to solve unknown connection issue
 pyyaml==5.4.1
 aiohttp==3.7.4.post0
 aiohttp_cors==0.7.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,3 @@ pytest==4.4.1
 pytest-cov==2.7.1
 pytest-timeout==1.3.3
 pytest-asyncio==0.10.0
-numpy==1.15.0


### PR DESCRIPTION
- numpy needs to stay compatible with latest tensorflow version which has constraints on the numpy version required. Make sure to check this before upgrading numpy.