### PR TITLE
Add release actions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,68 @@
+autolabeler:
+  - label: "github_actions"
+    files:
+      - ".github/workflows/*"
+  - label: "ci"
+    files:
+      - ".github/*"
+  - label: "documentation"
+    files:
+      - "*.md"
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: "bug"
+    branch:
+      - '/fix\/.+/'
+    title:
+      - "/fix/i"
+  - label: "enhancement"
+    branch:
+      - '/feature\/.+/'
+    title:
+      - "/add/i"
+  - label: "refactoring"
+    branch:
+      - '/refactor\/.+/'
+    title:
+      - "/refactor/i"
+  - label: "removal"
+    branch:
+      - '/remove\/.+/'
+    title:
+      - "/remove/i"
+  - label: "testing"
+    branch:
+      - '/test\/.+/'
+    title:
+      - "/test/i"
+categories:
+  - title: ":boom: Breaking Changes"
+    label: "breaking"
+  - title: ":rocket: Features"
+    label: "enhancement"
+  - title: ":fire: Removals and Deprecations"
+    label: "removal"
+  - title: ":beetle: Fixes"
+    label: "bug"
+  - title: ":racehorse: Performance"
+    label: "performance"
+  - title: ":rotating_light: Testing"
+    label: "testing"
+  - title: ":construction_worker: Continuous Integration"
+    labels:
+      - "ci"
+      - "github_actions"
+  - title: ":books: Documentation"
+    label: "documentation"
+  - title: ":hammer: Refactoring"
+    label: "refactoring"
+  - title: ":lipstick: Style"
+    label: "style"
+  - title: ":package: Dependencies"
+    labels:
+      - "dependencies"
+      - "build"
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,15 @@
+name: Draft release
+
+on:
+  workflow_dispatch:
+  # pull_request event is required only for autolabeler
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update-release-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5.15.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: "3.8"
+
+      - name: Upgrade pip
+        run: |
+          python -m pip install pip
+          pip --version
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements_pypi.txt
+
+      - name: Check if there is a parent commit
+        id: check-parent-commit
+        run: |
+          echo "::set-output name=sha::$(git rev-parse --verify --quiet HEAD^)"
+
+      - name: Detect and tag new version
+        id: check-version
+        if: steps.check-parent-commit.outputs.sha
+        uses: salsify/action-detect-and-tag-new-version@v2.0.1
+        with:
+          version-command: |
+            bash -o pipefail -c "cat imjoy/VERSION | jq -r '.version'"
+
+      - name: Build package
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Publish package on PyPI
+        if: steps.check-version.outputs.tag
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: "${{ secrets.PYPI_TOKEN }}"
+
+      - name: Publish the release notes
+        uses: release-drafter/release-drafter@v5.15.0
+        with:
+          publish: "${{ steps.check-version.outputs.tag != '' }}"
+          tag: "${{ steps.check-version.outputs.tag }}"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/requirements_pypi.txt
+++ b/requirements_pypi.txt
@@ -1,0 +1,3 @@
+setuptools==56.0.0
+twine==3.4.1
+wheel==0.36.2


### PR DESCRIPTION
- Add release drafter including autolabeling of PRs. The release drafter will draft release notes in GitHub releases.
- Add release workflow that will run on every push and check for a version bump. If it finds a version bump it will tag and release. It will check for version bump here:
https://github.com/imjoy-team/imjoy-engine/blob/175bcdaf36105f53b642d4fbea71cf8fc69422ec/imjoy/VERSION#L2