### PR TITLE
Use flake8-docstrings

### DIFF
--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,4 +1,4 @@
 black==19.10b0
 flake8==3.9.1
-pydocstyle==6.0.0
+flake8-docstrings==1.6.0
 pylint==2.7.4

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ ignore_errors = True
 commands =
   black --check ./
   flake8 ./
-  pydocstyle ./
   pylint imjoy setup.py tests
 deps =
   -rrequirements.txt


### PR DESCRIPTION
- We save some time and avoid config conflicts by using the pydocstyle plugin for flake8 instead of running pydocstyle directly.